### PR TITLE
OPENEUROPA-371: Task Runner: allow bin directory to be derived by composer.json "bin-dir" property

### DIFF
--- a/config/runner.yml
+++ b/config/runner.yml
@@ -5,8 +5,11 @@
 # -----------------------------------------------------------------------------
 # Global Task Runner settings
 # -----------------------------------------------------------------------------
+#
+# If ./runner.yml.dist or ./runner.yml doesn't override "runner.bin_dir" with a
+# non empty value, the Composer "config.bin-dir" value is used at runtime.
 runner:
-  bin_dir: "./vendor/bin"
+  bin_dir: ~
 
 # -----------------------------------------------------------------------------
 # Drupal-related settings.

--- a/src/Commands/AbstractCommands.php
+++ b/src/Commands/AbstractCommands.php
@@ -2,8 +2,8 @@
 
 namespace OpenEuropa\TaskRunner\Commands;
 
-use EC\OpenEuropa\TaskRunner\Contract\ComposerAwareInterface;
-use EC\OpenEuropa\TaskRunner\Traits\ComposerAwareTrait;
+use OpenEuropa\TaskRunner\Contract\ComposerAwareInterface;
+use OpenEuropa\TaskRunner\Traits\ComposerAwareTrait;
 use Robo\Common\ConfigAwareTrait;
 use Robo\Common\IO;
 use Robo\Contract\ConfigAwareInterface;

--- a/src/Commands/AbstractCommands.php
+++ b/src/Commands/AbstractCommands.php
@@ -60,14 +60,17 @@ abstract class AbstractCommands implements BuilderAwareInterface, IOAwareInterfa
     public function setRuntimeBinDir(ConsoleCommandEvent $event)
     {
         if ($this->getConfig()->get('runner.bin_dir') === null) {
-            if ($composerBinDir = $this->getComposer()->getConfig('bin-dir')) {
-                if (strpos($composerBinDir, './') === false) {
-                    $composerBinDir = "./$composerBinDir";
+            // The COMPOSER_BIN_DIR environment takes precedence over the value
+            // defined in composer.json config, if any. Default to ./vendor/bin.
+            if (!$composerBinDir = getenv('COMPOSER_BIN_DIR')) {
+                if (!$composerBinDir = $this->getComposer()->getConfig('bin-dir')) {
+                    $composerBinDir = './vendor/bin';
                 }
-                $composerBinDir = rtrim($composerBinDir, DIRECTORY_SEPARATOR);
-            } else {
-                $composerBinDir = './vendor/bin';
             }
+            if (strpos($composerBinDir, './') === false) {
+                $composerBinDir = "./$composerBinDir";
+            }
+            $composerBinDir = rtrim($composerBinDir, DIRECTORY_SEPARATOR);
             $this->getConfig()->set('runner.bin_dir', $composerBinDir);
         }
     }

--- a/src/Commands/AbstractCommands.php
+++ b/src/Commands/AbstractCommands.php
@@ -51,6 +51,28 @@ abstract class AbstractCommands implements BuilderAwareInterface, IOAwareInterfa
     }
 
     /**
+     * Set runtime "runner.bin_dir" configuration value.
+     *
+     * @param \Symfony\Component\Console\Event\ConsoleCommandEvent $event
+     *
+     * @hook command-event *
+     */
+    public function setRuntimeBinDir(ConsoleCommandEvent $event)
+    {
+        if ($this->getConfig()->get('runner.bin_dir') === null) {
+            if ($composerBinDir = $this->getComposer()->getConfig('bin-dir')) {
+                if (strpos($composerBinDir, './') === false) {
+                    $composerBinDir = "./$composerBinDir";
+                }
+                $composerBinDir = rtrim($composerBinDir, DIRECTORY_SEPARATOR);
+            } else {
+                $composerBinDir = './vendor/bin';
+            }
+            $this->getConfig()->set('runner.bin_dir', $composerBinDir);
+        }
+    }
+
+    /**
      * @param  string $name
      * @return string
      *
@@ -64,29 +86,6 @@ abstract class AbstractCommands implements BuilderAwareInterface, IOAwareInterfa
         }
 
         return $filename;
-    }
-
-    /**
-     * Set runtime "runner.bin_dir" configuration value.
-     *
-     * @param \Symfony\Component\Console\Event\ConsoleCommandEvent $event
-     *
-     * @hook command-event *
-     */
-    public function setRuntimeBinDir(ConsoleCommandEvent $event)
-    {
-        if ($this->getConfig()->get('runner.bin_dir') === null) {
-            if ($composerBinDir = $this->getComposer()->getConfig('bin-dir')) {
-                if (strpos($composerBinDir, './') === FALSE) {
-                    $composerBinDir = './' . $composerBinDir;
-                }
-                $composerBinDir = rtrim($composerBinDir, DIRECTORY_SEPARATOR);
-            }
-            else {
-                $composerBinDir = './vendor/bin';
-            }
-            $this->getConfig()->set('runner.bin_dir', $composerBinDir);
-        }
     }
 
     /**

--- a/src/Commands/ChangelogCommands.php
+++ b/src/Commands/ChangelogCommands.php
@@ -11,10 +11,8 @@ use Symfony\Component\Console\Input\InputOption;
  *
  * @package OpenEuropa\TaskRunner\Commands
  */
-class ChangelogCommands extends AbstractCommands implements ComposerAwareInterface
+class ChangelogCommands extends AbstractCommands
 {
-    use ComposerAwareTrait;
-
     /**
      * {@inheritdoc}
      */

--- a/src/Services/Composer.php
+++ b/src/Services/Composer.php
@@ -57,6 +57,16 @@ class Composer
     }
 
     /**
+     * @param string $configKey
+     *
+     * @return mixed
+     */
+    public function getConfig($configKey)
+    {
+        return isset($this->getPackage()->config->{$configKey}) ? $this->getPackage()->config->{$configKey} : null;
+    }
+
+    /**
      * @return bool
      */
     public function hasName()

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -21,6 +21,9 @@ abstract class AbstractTest extends TestCase
     {
         $filesystem = new Filesystem();
         $filesystem->remove(glob($this->getSandboxRoot()."/*"));
+        // Ensure at least an empty composer.json file.
+        $composerFile = $this->getSandboxFilepath('composer.json');
+        file_put_contents($composerFile, '');
     }
 
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -21,12 +21,12 @@ class CommandsTest extends AbstractTest
      * @param string $command
      * @param array  $config
      * @param string $composer
-     * @param array  $environment_vars
+     * @param array  $envVars
      * @param array  $expected
      *
      * @dataProvider simulationDataProvider
      */
-    public function testSimulation($command, array $config, $composer, array $environment_vars, array $expected)
+    public function testSimulation($command, array $config, $composer, array $envVars, array $expected)
     {
         $configFile = $this->getSandboxFilepath('runner.yml');
         $composerFile = $this->getSandboxFilepath('composer.json');
@@ -34,7 +34,7 @@ class CommandsTest extends AbstractTest
         file_put_contents($configFile, Yaml::dump($config));
         file_put_contents($composerFile, $composer);
 
-        array_walk($environment_vars, function ($value, $name) {
+        array_walk($envVars, function ($value, $name) {
             putenv("$name=$value");
         });
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -21,17 +21,22 @@ class CommandsTest extends AbstractTest
      * @param string $command
      * @param array  $config
      * @param string $composer
+     * @param array  $environment_vars
      * @param array  $expected
      *
      * @dataProvider simulationDataProvider
      */
-    public function testSimulation($command, array $config, $composer, array $expected)
+    public function testSimulation($command, array $config, $composer, array $environment_vars, array $expected)
     {
         $configFile = $this->getSandboxFilepath('runner.yml');
         $composerFile = $this->getSandboxFilepath('composer.json');
 
         file_put_contents($configFile, Yaml::dump($config));
         file_put_contents($composerFile, $composer);
+
+        array_walk($environment_vars, function ($value, $name) {
+            putenv("$name=$value");
+        });
 
         $input = new StringInput("{$command} --simulate --working-dir=".$this->getSandboxRoot());
         $output = new BufferedOutput();

--- a/tests/Services/ComposerTest.php
+++ b/tests/Services/ComposerTest.php
@@ -25,7 +25,12 @@ class ComposerTest extends AbstractTest
 
         $service = new Composer(dirname($filepath));
         foreach ($assertions as $method => $expected) {
-            $this->assertEquals($expected, $service->{$method}());
+            $params = [];
+            if (preg_match('/^(.*)\((.*)\)$/', $method, $found)) {
+                $method = $found[1];
+                $params = explode(',', $found[2]);
+            }
+            $this->assertEquals($expected, call_user_func_array([$service, $method], $params));
         }
     }
 

--- a/tests/fixtures/services/composer.yml
+++ b/tests/fixtures/services/composer.yml
@@ -36,3 +36,20 @@
     getType: ~
     hasName: false
     hasType: false
+
+-
+  composer: >
+    {
+        "config": {
+            "bin-dir": "arbitrary/path/"
+        }
+    }
+  expected:
+    getName: ~
+    getVendor: ~
+    getProject: ~
+    getType: ~
+    getConfig(bin-dir): arbitrary/path/
+    getConfig(non-existing-config): null
+    hasName: false
+    hasType: false

--- a/tests/fixtures/simulation.yml
+++ b/tests/fixtures/simulation.yml
@@ -1,18 +1,21 @@
 - command: "drupal:site-install"
   configuration: []
   composer: ''
+  environment: {  }
   contains:
     - "[Simulator] Running ./vendor/bin/drush -y --root=$(pwd)/build --site-name='Site name' --site-mail=info@example.org --locale=en --account-mail=admin@example.org --account-name=admin --account-pass=admin --sites-subdir=default --db-url='mysql://root:root@127.0.0.1:3306/drupal' site-install standard"
 
 - command: 'drupal:site-install --site-name="Test site"'
   configuration: []
   composer: ''
+  environment: {  }
   contains:
     - "[Simulator] Running ./vendor/bin/drush -y --root=$(pwd)/build --site-name='Test site' --site-mail=info@example.org --locale=en --account-mail=admin@example.org --account-name=admin --account-pass=admin --sites-subdir=default --db-url='mysql://root:root@127.0.0.1:3306/drupal' site-install standard"
 
 - command: 'drupal:site-install --site-mail="test@example.com" --site-profile=minimal'
   configuration: []
   composer: ''
+  environment: {  }
   contains:
     - "site-install minimal"
     - "--site-mail=test@example.com"
@@ -24,6 +27,7 @@
       site:
         profile: 'minimal'
   composer: ''
+  environment: {  }
   contains:
     - "./vendor/bin/drush -y --root=$(pwd)/test"
     - "site-install minimal"
@@ -33,6 +37,7 @@
     drupal:
       root: './test'
   composer: ''
+  environment: {  }
   contains:
     - "./vendor/bin/drush -y --root=$(pwd)/overridden"
 
@@ -40,9 +45,40 @@
   configuration:
     runner:
       bin_dir: "./bin"
-  composer: ''
+  composer: >
+    {
+      "config": {
+        "bin-dir": "some/arbitrary/path"
+      }
+    }
+  environment: {  }
   contains:
     - "./bin/drush -y --root=$(pwd)/overridden"
+
+- command: 'drupal:site-install --root="overridden"'
+  configuration: {  }
+  composer: >
+    {
+      "config": {
+        "bin-dir": "some/arbitrary/path"
+      }
+    }
+  environment: {  }
+  contains:
+    - "./some/arbitrary/path/drush -y --root=$(pwd)/overridden"
+
+- command: 'drupal:site-install --root="overridden"'
+  configuration: {  }
+  composer: >
+    {
+      "config": {
+        "bin-dir": "some/arbitrary/path"
+      }
+    }
+  environment:
+    COMPOSER_BIN_DIR: this/path/will/take/precedence
+  contains:
+    - "./this/path/will/take/precedence/drush -y --root=$(pwd)/overridden"
 
 - command: 'changelog:generate'
   configuration:
@@ -52,6 +88,7 @@
     {
       "name": "foo/bar"
     }
+  environment: {  }
   contains:
     - "exec('foo/bar -t abc')"
 
@@ -63,6 +100,7 @@
     {
       "name": "foo/bar"
     }
+  environment: {  }
   contains:
     - "exec('foo/bar -t def')"
 
@@ -74,6 +112,7 @@
     {
       "name": "foo/bar"
     }
+  environment: {  }
   contains:
     - "exec('foo/bar -t abc --future-release=1.2.3')"
 
@@ -85,6 +124,7 @@
     {
       "name": "foo/bar"
     }
+  environment: {  }
   contains:
     - "exec('foo/bar -t 123 --future-release=1.2.3')"
 
@@ -95,6 +135,7 @@
         - "./vendor/bin/drush en views -y"
         - "./vendor/bin/drush cr"
   composer: ''
+  environment: {  }
   contains:
     - "./vendor/bin/drush en views -y"
     - "./vendor/bin/drush cr"
@@ -106,6 +147,7 @@
         - "./vendor/bin/drush en views -y"
         - "./vendor/bin/drush cr"
   composer: ''
+  environment: {  }
   contains:
     - "[Simulator] Running ./vendor/bin/drush -y --root=$(pwd)/build --site-name='Site name' --site-mail=info@example.org --locale=en --account-mail=admin@example.org --account-name=admin --account-pass=admin --sites-subdir=default --db-url='mysql://root:root@127.0.0.1:3306/drupal' site-install standard"
     - "./vendor/bin/drush en views -y"
@@ -117,6 +159,7 @@
       post_install:
         - "./vendor/bin/drush --root=${drupal.root} en views -y"
   composer: ''
+  environment: {  }
   contains:
     - "./vendor/bin/drush --root=build en views -y"
 
@@ -125,6 +168,7 @@
     drupal:
       post_install: []
   composer: ''
+  environment: {  }
   contains:
     - "[Simulator] Running ./vendor/bin/drush -y --root=$(pwd)/build --site-name='Site name' --site-mail=info@example.org --locale=en --account-mail=admin@example.org --account-name=admin --account-pass=admin --sites-subdir=default --db-url='mysql://root:root@127.0.0.1:3306/drupal' site-install standard"
 
@@ -135,6 +179,7 @@
         - { task: "symlink", from: "${drupal.root}/modules/custom", to: "../../custom/modules" }
         - { task: "symlink", from: "${drupal.root}/modules/custom", to: "../../custom/themes" }
   composer: ''
+  environment: {  }
   contains:
     - "[Simulator] { task: symlink, from: build/modules/custom, to: ../../custom/modules }"
     - "[Simulator] { task: symlink, from: build/modules/custom, to: ../../custom/themes }"
@@ -142,6 +187,7 @@
 - command: 'drupal:drush-setup'
   configuration: []
   composer: ''
+  environment: {  }
   contains:
     - "WriteConfiguration('build/sites/default/drushrc.php'"
     - "File\\Write('build/drush/drush.yml')"
@@ -149,6 +195,7 @@
 - command: 'drupal:drush-setup --root=web --config-dir=./drush'
   configuration: []
   composer: ''
+  environment: {  }
   contains:
     - "WriteConfiguration('web/sites/default/drushrc.php'"
     - "File\\Write('./drush/drush.yml')"
@@ -156,12 +203,14 @@
 - command: 'drupal:settings-setup'
   configuration: []
   composer: ''
+  environment: {  }
   contains:
     - "AppendConfiguration('build/sites/default/default.settings.php'"
 
 - command: 'drupal:settings-setup --root=web'
   configuration: []
   composer: ''
+  environment: {  }
   contains:
     - "AppendConfiguration('web/sites/default/default.settings.php'"
 
@@ -184,6 +233,7 @@
       setup:phpunit:
         - { task: "process", source: "phpunit.xml.dist", destination: "phpunit.xml" }
   composer: ''
+  environment: {  }
   contains:
     - "{ task: chmod, file: web/sites, permissions: 509 }"
     - "{ task: symlink, from: ../../custom/modules, to: web/modules/custom }"


### PR DESCRIPTION
In my projects, I like to use `./bin` as binary directory. This is easy to config in `composer.json`:

```json
    "config": {
        "bin-dir": "bin/"
    },
```

But the task runner uses its own bin dir, independent from composer.

**Proposal**: Default to Composer's bin dir but still allow to override this behaviour in `./runner.yml.dist` or `./runner.yml`.