### PR TITLE
OPENEUROPA-372: Allow custom commands to define options

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,46 @@ At the moment the following tasks are supported (optional argument default value
 
 Tasks provided as plain-text strings will be executed as is in the current working directory.
 
+### Advanced custom commands
+
+You can define also command options along with a custom command. Let's see how the previous defined `setup:behat` custom command can have its own command options:
+
+```yaml
+commands:
+  setup:behat:
+    # When you need to define command options, the list of tasks should be
+    # placed under the 'tasks' key...
+    tasks:
+      - { task: "process", source: "behat.yml.dist", destination: "behat.yml" }
+    # ...and option definitions are under 'options' key.
+    options:
+      # The option name, without the leading double dash ('--').
+      webdriver-url:
+        # Optional. If this key is present, the input option value is assigned
+        # to this configuration entry. This a key feature because in this way
+        # you're able to override configuration values, making it very helpful
+        # in CI flows.
+        config: behat.webdriver_url
+        # Optional. You can provide a list of shortcuts to the command, without
+        # adding the dash ('-') prefix.
+        shortcut:
+          - wdu
+          - wurl
+        # The mode of this option. See the Symfony `InputOption::VALUE_*`
+        # constants. Several options can be combined.
+        # @see \Symfony\Component\Console\Input\InputOption::VALUE_NONE
+        # @see \Symfony\Component\Console\Input\InputOption::VALUE_REQUIRED
+        # @see \Symfony\Component\Console\Input\InputOption::VALUE_OPTIONAL
+        # @see \Symfony\Component\Console\Input\InputOption::VALUE_IS_ARRAY
+        mode: 4
+        # Optional. A description for this option. This is displayed when
+        # asking for help. E.g. `./vendor/bin/run setup:behat --help`.
+        description: 'The webdriver URL.'
+        # Optional. A default value when an optional option is not present in
+        # the input.
+        default: null
+```
+
 ## Expose custom commands as PHP classes
 
 More complex commands can be provided by creating Task Runner command classes within your project's PSR-4 namespace.

--- a/src/Commands/DynamicCommands.php
+++ b/src/Commands/DynamicCommands.php
@@ -25,7 +25,14 @@ class DynamicCommands extends AbstractCommands
         $command = $this->input()->getArgument('command');
         $tasks = $this->getConfig()->get("commands.{$command}");
 
-        return $this->taskCollectionFactory($tasks);
+        $inputOptions = [];
+        foreach ($this->input()->getOptions() as $name => $value) {
+            if ($this->input()->hasParameterOption("--$name")) {
+                $inputOptions[$name] = $value;
+            }
+        }
+
+        return $this->taskCollectionFactory($tasks, $inputOptions);
     }
 
     /**

--- a/src/Commands/DynamicCommands.php
+++ b/src/Commands/DynamicCommands.php
@@ -2,10 +2,8 @@
 
 namespace OpenEuropa\TaskRunner\Commands;
 
-use Consolidation\AnnotatedCommand\AnnotationData;
-use Consolidation\AnnotatedCommand\CommandData;
+use Consolidation\AnnotatedCommand\AnnotatedCommand;
 use OpenEuropa\TaskRunner\Tasks as TaskRunnerTasks;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 
 /**
@@ -18,6 +16,8 @@ class DynamicCommands extends AbstractCommands
     use TaskRunnerTasks\CollectionFactory\loadTasks;
 
     /**
+     * @dynamic-command true
+     *
      * @return \OpenEuropa\TaskRunner\Tasks\CollectionFactory\CollectionFactory
      */
     public function runTasks()
@@ -26,5 +26,42 @@ class DynamicCommands extends AbstractCommands
         $tasks = $this->getConfig()->get("commands.{$command}");
 
         return $this->taskCollectionFactory($tasks);
+    }
+
+    /**
+     * Bind input values of custom command options to config entries.
+     *
+     * @param \Symfony\Component\Console\Event\ConsoleCommandEvent $event
+     *
+     * @hook pre-command-event *
+     */
+    public function bindInputOptionsToConfig(ConsoleCommandEvent $event)
+    {
+        $command = $event->getCommand();
+        if (get_class($command) !== AnnotatedCommand::class && !is_subclass_of($command, AnnotatedCommand::class)) {
+            return;
+        }
+
+        /** @var \Consolidation\AnnotatedCommand\AnnotatedCommand $command */
+        /** @var \Consolidation\AnnotatedCommand\AnnotationData $annotatedData */
+        $annotatedData = $command->getAnnotationData();
+        if (!$annotatedData->get('dynamic-command')) {
+            return;
+        }
+
+        // Dynamic commands may define their own options bound to specific configuration. Dynamically set the
+        // configuration from command options.
+        $config = $this->getConfig();
+        $commands = $config->get('commands');
+        if (!empty($commands[$command->getName()]['options'])) {
+            foreach ($commands[$command->getName()]['options'] as $optionName => $option) {
+                if (!empty($option['config']) && $event->getInput()->hasOption($optionName)) {
+                    $inputValue = $event->getInput()->getOption($optionName);
+                    if ($inputValue !== null) {
+                        $config->set($option['config'], $event->getInput()->getOption($optionName));
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -64,7 +64,7 @@ class TaskRunner
     /**
      * TaskRunner constructor.
      *
-     * @param InputInterface $input
+     * @param InputInterface       $input
      * @param OutputInterface|null $output
      */
     public function __construct(InputInterface $input = null, OutputInterface $output = null)
@@ -119,7 +119,7 @@ class TaskRunner
 
         foreach ($classLoader->getPrefixesPsr4() as $baseNamespace => $directoryList) {
             $directoryList = array_filter($directoryList, function ($path) {
-                return is_dir($path . '/TaskRunner/Commands');
+                return is_dir($path.'/TaskRunner/Commands');
             });
 
             if (!empty($directoryList)) {
@@ -150,7 +150,7 @@ class TaskRunner
     private function createConfiguration()
     {
         return Robo::createConfiguration([
-            __DIR__ . '/../config/runner.yml',
+            __DIR__.'/../config/runner.yml',
             'runner.yml.dist',
             'runner.yml',
         ]);
@@ -215,7 +215,7 @@ class TaskRunner
         $customCommands = $this->getConfig()->get('commands', []);
         foreach ($customCommands as $name => $commandDefinition) {
             /** @var \Consolidation\AnnotatedCommand\AnnotatedCommandFactory $commandFactory */
-            $commandFileName = DynamicCommands::class . "Commands";
+            $commandFileName = DynamicCommands::class."Commands";
             $commandClass = $this->container->get($commandFileName);
             $commandFactory = $this->container->get('commandFactory');
             $commandInfo = $commandFactory->createCommandInfo($commandClass, 'runTasks');

--- a/src/Tasks/CollectionFactory/loadTasks.php
+++ b/src/Tasks/CollectionFactory/loadTasks.php
@@ -11,11 +11,12 @@ trait loadTasks
 {
     /**
      * @param array $tasks
+     * @param array $options
      *
      * @return \OpenEuropa\TaskRunner\Tasks\CollectionFactory\CollectionFactory
      */
-    public function taskCollectionFactory(array $tasks)
+    public function taskCollectionFactory(array $tasks, array $options = [])
     {
-        return $this->task(CollectionFactory::class, $tasks);
+        return $this->task(CollectionFactory::class, $tasks, $options);
     }
 }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -1,11 +1,9 @@
 <?php
 
-namespace OpenEuropa\TaskRunner\Tests\Commands;
+namespace OpenEuropa\TaskRunner\Tests;
 
-use Consolidation\AnnotatedCommand\CommandFileDiscovery;
 use OpenEuropa\TaskRunner\Commands\ChangelogCommands;
 use OpenEuropa\TaskRunner\TaskRunner;
-use OpenEuropa\TaskRunner\Tests\AbstractTest;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Yaml\Yaml;
@@ -13,7 +11,7 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Class DrupalCommandsTest.
  *
- * @package OpenEuropa\TaskRunner\Tests\Commands
+ * @package OpenEuropa\TaskRunner\Tests
  */
 class CommandsTest extends AbstractTest
 {

--- a/tests/fixtures/setup.yml
+++ b/tests/fixtures/setup.yml
@@ -49,3 +49,36 @@
         <env name="BASE_URL" value="http://127.0.0.1:8888"/>
       </php>
     </phpunit>
+
+- command: "setup:behat --drupal-base-url=http://localhost/drupal"
+  source: behat.yml.dist
+  destination: behat.yml
+  configuration:
+    drupal:
+      base_url: http://127.0.0.1
+    commands:
+      setup:behat:
+        tasks:
+          - { task: "process", source: "behat.yml.dist", destination: "behat.yml" }
+        options:
+          drupal-base-url:
+            config: drupal.base_url
+            shortcut:
+              - dbu
+            mode: 4
+            description: 'The Drupal base URL.'
+            default: null
+  content: >
+    default:
+      extensions:
+        Behat\MinkExtension:
+          base_url: ${drupal.base_url}
+      formatters:
+        progress: ~
+  expected: >
+    default:
+      extensions:
+        Behat\MinkExtension:
+          base_url: http://localhost/drupal
+      formatters:
+        progress: ~


### PR DESCRIPTION
## Problem

As the README states, the runner config can be controlled either by arguments and options passed on the command line or by configuring the values in the `runner.yml.dist` and `runner.yml` files. However, passing options to the command line is true for regular annotated commands. But this library introduces the concept of _dynamic commands_. And for such commands there's no way to define run-time options. How to override in CI a specific config value for the `drupal:site-setup`, for instance, which is defined dynamically?

## Proposal

TL;DR Allow options that can be bound to config entries for custom commands.

Allow defining options for custom commands. Such options could be bound to a specific config entry to overwrite it. See the README and the test added in this PR for details.

Also, custom commands that have subsequent tasks, are exposing also their options, so that calling a custom command with options, when is executed, will pass the options to subsequent tasks.