### PR TITLE
External commands should be registered before custom commands

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -3,6 +3,7 @@
 
 use Symfony\Component\Console\Input\ArgvInput;
 use OpenEuropa\TaskRunner\TaskRunner;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 if (file_exists(__DIR__.'/../vendor/autoload.php')) {
     $classLoader = require __DIR__.'/../vendor/autoload.php';
@@ -10,6 +11,5 @@ if (file_exists(__DIR__.'/../vendor/autoload.php')) {
     $classLoader = require __DIR__ . '/../../../autoload.php';
 }
 
-$runner = new TaskRunner();
-$runner->registerExternalCommands($classLoader);
+$runner = new TaskRunner(new ArgvInput(), new ConsoleOutput(), $classLoader);
 exit($runner->run());

--- a/tests/AbstractTaskTest.php
+++ b/tests/AbstractTaskTest.php
@@ -31,7 +31,8 @@ abstract class AbstractTaskTest extends AbstractTest implements ContainerAwareIn
     public function setup()
     {
         $this->output = new BufferedOutput();
-        $runner = new TaskRunner(new StringInput(''), $this->output);
+        $classLoader = require __DIR__.'/../vendor/autoload.php';
+        $runner = new TaskRunner(new StringInput(''), $this->output, $classLoader);
         $this->setContainer($runner->getContainer());
     }
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -35,7 +35,7 @@ class CommandsTest extends AbstractTest
 
         $input = new StringInput("{$command} --simulate --working-dir=".$this->getSandboxRoot());
         $output = new BufferedOutput();
-        $runner = new TaskRunner($input, $output);
+        $runner = new TaskRunner($input, $output, $this->getClassLoader());
         $runner->run();
 
         $text = $output->fetch();
@@ -65,7 +65,7 @@ class CommandsTest extends AbstractTest
 
         $input = new StringInput("{$command} --working-dir=".$this->getSandboxRoot());
         $output = new BufferedOutput();
-        $runner = new TaskRunner($input, $output);
+        $runner = new TaskRunner($input, $output, $this->getClassLoader());
         $runner->run();
 
         $actual = file_get_contents($destination);
@@ -96,9 +96,7 @@ class CommandsTest extends AbstractTest
     {
         $input = new StringInput("list");
         $output = new BufferedOutput();
-        $runner = new TaskRunner($input, $output);
-        $classLoader = require __DIR__.'/../vendor/autoload.php';
-        $runner->registerExternalCommands($classLoader);
+        $runner = new TaskRunner($input, $output, $this->getClassLoader());
         $runner->run();
 
         $expected = [
@@ -127,7 +125,7 @@ class CommandsTest extends AbstractTest
         file_put_contents($configFile, Yaml::dump($config));
 
         $input = new StringInput("drupal:drush-setup --working-dir=".$this->getSandboxRoot());
-        $runner = new TaskRunner($input, new BufferedOutput());
+        $runner = new TaskRunner($input, new BufferedOutput(), $this->getClassLoader());
         $runner->run();
 
         foreach ($expected as $row) {
@@ -149,7 +147,7 @@ class CommandsTest extends AbstractTest
         file_put_contents($configFile, Yaml::dump($config));
 
         $input = new StringInput("drupal:settings-setup --working-dir=".$this->getSandboxRoot());
-        $runner = new TaskRunner($input, new BufferedOutput());
+        $runner = new TaskRunner($input, new BufferedOutput(), $this->getClassLoader());
         $runner->run();
 
 
@@ -209,5 +207,13 @@ class CommandsTest extends AbstractTest
         if (!empty($row['not_contains'])) {
             $this->assertNotContains($row['not_contains'], $content);
         }
+    }
+
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
+    protected function getClassLoader()
+    {
+        return require __DIR__.'/../vendor/autoload.php';
     }
 }


### PR DESCRIPTION
## Problem

Right now, the dynamic/custom commands are registered in the `TaskRunner` constructor. The external commands, provided by 3rd party, are registered after `TaskRunner` has been constructed, in `./bin/run`:

```php
$runner = new TaskRunner();
$runner->registerExternalCommands($classLoader);
```

For this reason a custom command cannot add an external command as a task because at that moment the external command is not yet registered.

## Solution

Call `::registerExternalCommands()` from the `TaskRunner` constructor, just before calling `::registerDynamicCommands()`.