### PR TITLE
OPENEUROPA-1569: Task-Runner: Add support in task-runner "process" task arrays (imploded to string with comma delimiter).

### DIFF
--- a/src/Commands/AbstractDrupalCommands.php
+++ b/src/Commands/AbstractDrupalCommands.php
@@ -391,7 +391,7 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
 
         // Define collection of tasks.
         $collection = [
-            // Note that the chmod() method takes decimal values.
+        // Note that the chmod() method takes decimal values.
             $this->taskFilesystemStack()->chmod($subdirPath, octdec(775), 0000, true),
         ];
 

--- a/src/Commands/AbstractDrupalCommands.php
+++ b/src/Commands/AbstractDrupalCommands.php
@@ -13,8 +13,6 @@ use Symfony\Component\Yaml\Yaml;
 
 /**
  * Class DrupalCommands.
- *
- * @package OpenEuropa\TaskRunner\Commands
  */
 abstract class AbstractDrupalCommands extends AbstractCommands implements FilesystemAwareInterface
 {
@@ -391,7 +389,7 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
 
         // Define collection of tasks.
         $collection = [
-        // Note that the chmod() method takes decimal values.
+            // Note that the chmod() method takes decimal values.
             $this->taskFilesystemStack()->chmod($subdirPath, octdec(775), 0000, true),
         ];
 

--- a/src/Traits/ConfigurationTokensTrait.php
+++ b/src/Traits/ConfigurationTokensTrait.php
@@ -2,6 +2,9 @@
 
 namespace OpenEuropa\TaskRunner\Traits;
 
+use RecursiveArrayIterator;
+use RecursiveIteratorIterator;
+
 /**
  * Class ConfigurationTokensTrait
  *
@@ -41,7 +44,7 @@ trait ConfigurationTokensTrait
         return array_map(function ($key) use ($config) {
             $value = $config->get($key);
             if (is_array($value)) {
-                return implode(',', $value);
+                return implode(',', iterator_to_array(new RecursiveIteratorIterator(new RecursiveArrayIterator($value))));
             }
             return $value;
         }, $this->extractRawTokens($text));

--- a/src/Traits/ConfigurationTokensTrait.php
+++ b/src/Traits/ConfigurationTokensTrait.php
@@ -39,7 +39,11 @@ trait ConfigurationTokensTrait
         $config = $this->getConfig();
 
         return array_map(function ($key) use ($config) {
-            return $config->get($key);
+            $value = $config->get($key);
+            if (is_array($value)) {
+                return implode(',', $value);
+            }
+            return $value;
         }, $this->extractRawTokens($text));
     }
 }

--- a/tests/fixtures/tasks/process-config-file/task.yml
+++ b/tests/fixtures/tasks/process-config-file/task.yml
@@ -23,5 +23,7 @@
 
 - source:
     comma-delimited: "${drupal.account}"
+    nested-comma-delimited: "${drupal.drush}"
   expected:
     comma-delimited: "admin,admin,admin@example.org"
+    nested-comma-delimited: "http://127.0.0.1:8888"

--- a/tests/fixtures/tasks/process-config-file/task.yml
+++ b/tests/fixtures/tasks/process-config-file/task.yml
@@ -20,3 +20,8 @@
     concat: "${drupal.root}/${drupal.site.profile}"
   expected:
     concat: "build/standard"
+
+- source:
+    comma-delimited: "${drupal.account}"
+  expected:
+    comma-delimited: "admin,admin,admin@example.org"


### PR DESCRIPTION
## OPENEUROPA-1569

### Description

For example in `phpunit.xml.dist` we have this code:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<phpunit bootstrap="${drupal.root}/core/tests/bootstrap.php" backupGlobals="true" colors="true" >
  <php>
    <ini name="error_reporting" value="32767"/>
    <ini name="memory_limit" value="-1"/>
    <env name="SIMPLETEST_IGNORE_DIRECTORIES" value="build,vendor,node_modules,${drupal.root}"/>
    <env name="SIMPLETEST_BASE_URL" value="${drupal.base_url}"/>
    <env name="SIMPLETEST_DB" value="mysql://${drupal.database.user}:${drupal.database.password}@${drupal.database.host}:${drupal.database.port}/${drupal.database.name}"/>
  </php>
  <testsuites>
    <testsuite>
      <directory>./modules/**/tests/</directory>
      <directory>./tests/</directory>
    </testsuite>
  </testsuites>
</phpunit>
```

It would be nice if we could use in `SIMPLETEST_IGNORE_DIRECTORIES` the value `${drupal.settings.settings.file_scan_ignore_directories}`.

Update of `phpunit.xml.dist` file in all existing components is optional in terms of ticket's scope.



### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

