### PR TITLE
Issue #95: Upgrade minimum version of Robo so it works with Drush 8.2.0 properly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "consolidation/robo": "^1.3",
+        "consolidation/robo": "^1.4",
         "gitonomy/gitlib": "^1.0",
         "nuvoleweb/robo-config": "^0.2.1",
         "jakeasmith/http_build_url": "^1.0.1"


### PR DESCRIPTION
Fix #95 