### PR TITLE
OPENEUROPA-2258: Use PHP 7.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,6 +50,7 @@ matrix:
   IMAGE_PHP:
   - fpfis/httpd-php-ci:5.6
   - fpfis/httpd-php-ci:7.1
+  - fpfis/httpd-php-ci:7.2
   COMPOSER_BOUNDARY:
   - lowest
   - highest

--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,17 @@
     "require": {
         "consolidation/robo": "^1.4",
         "gitonomy/gitlib": "^1.0",
-        "nuvoleweb/robo-config": "^0.2.1",
-        "jakeasmith/http_build_url": "^1.0.1"
+        "jakeasmith/http_build_url": "^1.0.1",
+        "nuvoleweb/robo-config": "^0.2.1"
     },
     "require-dev": {
         "openeuropa/code-review": "~1.0.0-beta3",
-        "phpunit/phpunit": "~5.5||~6.0"
+        "phpunit/phpunit": "~5.5||~6.0",
+        "sebastian/comparator": "^1.2.4"
     },
+    "_readme": [
+        "We explicitly require sebastian/comparator to allow tests using 'composer update --prefer-lowest' to complete successfully."
+    ],
     "autoload": {
         "psr-4": {
             "OpenEuropa\\TaskRunner\\": "./src/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: fpfis/httpd-php-dev:7.2
     working_dir: /var/www/html
     ports:
       - 8080:8080


### PR DESCRIPTION
## OPENEUROPA-2258

### Description

Use PHP 7.2 in drone and docker image.

### Change log

- Added: PHP 7.2 usage in docker-compose and drone
- Fixed: Lower composer compatibility for sebastian/comparator.