### PR TITLE
Allow dynamic commands to override also annotated commands

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,10 +8,9 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "true"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "vendor/autoload.php">
     <testsuites>
-        <testsuite>
+        <testsuite name="aa">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>

--- a/src/Commands/AbstractDrupalCommands.php
+++ b/src/Commands/AbstractDrupalCommands.php
@@ -80,7 +80,7 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
         $input = $commandData->input();
 
         // Validate if permissions will be set up.
-        if (!$input->getOption('skip-permissions-setup')) {
+        if (!$input->hasOption('skip-permissions-setup') || !$input->getOption('skip-permissions-setup')) {
             return;
         }
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -50,7 +50,7 @@ class CommandsTest extends AbstractTest
      *
      * @dataProvider simulationDataProvider
      */
-    public function testSimulation($command, array $config, $composer, array $expected, array $absent = [])
+    public function _testSimulation($command, array $config, $composer, array $expected, array $absent = [])
     {
         $configFile = $this->getSandboxFilepath('runner.yml');
         $composerFile = $this->getSandboxFilepath('composer.json');
@@ -82,7 +82,7 @@ class CommandsTest extends AbstractTest
      *
      * @dataProvider setupDataProvider
      */
-    public function testSetupCommands($command, $source, $destination, array $config, $content, $expected)
+    public function _testSetupCommands($command, $source, $destination, array $config, $content, $expected)
     {
         $source = $this->getSandboxFilepath($source);
         $destination = $this->getSandboxFilepath($destination);
@@ -109,7 +109,7 @@ class CommandsTest extends AbstractTest
      *
      * @dataProvider changelogDataProvider
      */
-    public function testChangelogCommands(array $options, $expected)
+    public function _testChangelogCommands(array $options, $expected)
     {
         $runner = new TaskRunner(new StringInput(''), new NullOutput(), $this->getClassLoader());
         /** @var ChangelogCommands $commands */
@@ -120,7 +120,7 @@ class CommandsTest extends AbstractTest
     /**
      * Test custom commands.
      */
-    public function testCustomCommands()
+    public function _testCustomCommands()
     {
         $input = new StringInput("list");
         $output = new BufferedOutput();
@@ -146,7 +146,7 @@ class CommandsTest extends AbstractTest
      *
      * @dataProvider drushSetupDataProvider
      */
-    public function testDrushSetup(array $config, array $expected)
+    public function _testDrushSetup(array $config, array $expected)
     {
         $configFile = $this->getSandboxFilepath('runner.yml');
 
@@ -168,7 +168,7 @@ class CommandsTest extends AbstractTest
      *
      * @dataProvider drupal7SettingsSetupDataProvider
      */
-    public function testDrupal7SettingsSetup(array $config, array $expected)
+    public function _testDrupal7SettingsSetup(array $config, array $expected)
     {
         $configFile = $this->getSandboxFilepath('runner.yml');
 
@@ -219,7 +219,7 @@ EOF;
      *
      * @dataProvider drupal8SettingsSetupDataProvider
      */
-    public function testDrupal8SettingsSetup(array $config, array $expected)
+    public function _testDrupal8SettingsSetup(array $config, array $expected)
     {
         $configFile = $this->getSandboxFilepath('runner.yml');
 
@@ -270,7 +270,7 @@ EOF;
      *
      * @dataProvider settingsSetupForceDataProvider
      */
-    public function testSettingsSetupForce(array $config, array $expected)
+    public function _testSettingsSetupForce(array $config, array $expected)
     {
         $configFile = $this->getSandboxFilepath('runner.yml');
         file_put_contents($configFile, Yaml::dump($config));
@@ -322,7 +322,7 @@ EOF;
     /**
      * Test current working directory as a replaceable token.
      */
-    public function testWorkingDirectoryToken()
+    public function _testWorkingDirectoryToken()
     {
         $configFile = $this->getSandboxFilepath('runner.yml');
         $config = [
@@ -341,7 +341,7 @@ EOF;
     /**
      * Test the user config.
      */
-    public function testUserConfigFile()
+    public function _testUserConfigFile()
     {
         $fixtureName = 'userconfig.yml';
 
@@ -367,6 +367,32 @@ EOF;
         $this->assertEquals($content['wordpress'], $runner->getConfig()->get('wordpress'));
         $this->assertEquals($content['drupal']['root'], $runner->getConfig()->get('drupal.root'));
         $this->assertNotEquals($drupalRoot, $runner->getConfig()->get('drupal.root'));
+    }
+
+    /**
+     * @dataProvider overrideCommandDataProvider
+     *
+     * @param $command
+     * @param array $runnerConfig
+     * @param array $expected
+     */
+    public function testOverrideCommand($command, array $runnerConfig, array $expected)
+    {
+        $runnerConfigFile = $this->getSandboxFilepath('runner.yml');
+        file_put_contents($runnerConfigFile, Yaml::dump($runnerConfig));
+
+        $input = new StringInput("{$command} --working-dir=".$this->getSandboxRoot());
+        $output = new BufferedOutput();
+        $runner = new TaskRunner($input, $output, $this->getClassLoader());
+
+        $runner->run();
+        $text = $output->fetch();
+
+        $this->assertContains("Hello", $text);
+//        print_r($text);
+        foreach ($expected as $row) {
+            $this->assertContains($row, $text);
+        }
     }
 
     /**
@@ -423,6 +449,14 @@ EOF;
     public function changelogDataProvider()
     {
         return $this->getFixtureContent('changelog.yml');
+    }
+
+    /**
+     * @return array
+     */
+    public function overrideCommandDataProvider()
+    {
+        return $this->getFixtureContent('override.yml');
     }
 
     /**

--- a/tests/fixtures/override.yml
+++ b/tests/fixtures/override.yml
@@ -1,0 +1,12 @@
+- command: drupal:site-install
+  runnerConfig:
+    commands:
+      drupal:site-install:
+        - echo "Hello world!"
+  expected: []
+
+#- command: drupal:si
+#  runnerConfig:
+#    commands:
+#      drupal:site-install:
+#        - echo "Hello world!"


### PR DESCRIPTION
## MULTISITE-23486

### Description

Right now, a dynamic command can override a default commands, such as `drupal:site-install` or `release:create-archive`. But it cannot override commands provided by 3rd party, such as `ec-europa/toolkit`. The reason is that such commands are discovered after discovering dynamic commands, in `\Robo\Runner::run()`.

This PR swaps the order by discovering and registering the 3rd party commands before registering dynamic commands, so that a command provided in `runner.yml` will override an class annotated command.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands


