### PR TITLE
MULTISITE-23486: Allow dynamic commands to override all code provided commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ The Task Runner comes with the following built-in commands:
 
 Run `./vendor/bin/run help [command-name]` for more information about each command's capabilities.
 
-## Expose custom commands as YAML configuration
+## Expose "dynamic" commands as YAML configuration
 
 The Task Runner allows you to expose new commands by just listing its [tasks](http://robo.li/getting-started/#tasks)
 under the `commands:` property in `runner.yml.dist`/`runner.yml`.
 
-For example, the following YAML portion will expose two commands, `drupal:site-setup` and `setup:behat`:
+For example, the following YAML portion will expose two dynamic commands, `drupal:site-setup` and `setup:behat`:
 
 ```yaml
 commands:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "consolidation/robo": "^1.4",
         "gitonomy/gitlib": "^1.0",
         "jakeasmith/http_build_url": "^1.0.1",
-        "nuvoleweb/robo-config": "^0.2.1"
+        "nuvoleweb/robo-config": "^0.2.1",
+        "symfony/console": "^3.4.21|^4|^5"
     },
     "require-dev": {
         "openeuropa/code-review": "~1.0.0-beta3",

--- a/src/Commands/AbstractDrupalCommands.php
+++ b/src/Commands/AbstractDrupalCommands.php
@@ -74,6 +74,8 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
      *
      * @param CommandData $commandData
      * @throws \Exception
+     *   Thrown when the settings file or its containing folder does not exist
+     *   or is not writeable.
      */
     public function validateSiteInstall(CommandData $commandData)
     {

--- a/src/Commands/AbstractDrupalCommands.php
+++ b/src/Commands/AbstractDrupalCommands.php
@@ -80,7 +80,7 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
         $input = $commandData->input();
 
         // Validate if permissions will be set up.
-        if (!$input->getOption('skip-permissions-setup')) {
+        if (!$input->hasOption('skip-permissions-setup') || !$input->getOption('skip-permissions-setup')) {
             return;
         }
 

--- a/src/Commands/DrupalCommands.php
+++ b/src/Commands/DrupalCommands.php
@@ -12,9 +12,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * Class DrupalCommands.
+ * Base class for commands that interact with a Drupal installation.
  *
- * @package OpenEuropa\TaskRunner\Commands
+ * This contains shared code that can be used in commands regardless of the
+ * Drupal version they target.
  */
 class DrupalCommands extends AbstractDrupalCommands
 {

--- a/src/Commands/DynamicCommands.php
+++ b/src/Commands/DynamicCommands.php
@@ -3,6 +3,7 @@
 namespace OpenEuropa\TaskRunner\Commands;
 
 use OpenEuropa\TaskRunner\Tasks as TaskRunnerTasks;
+use Robo\Robo;
 
 /**
  * Class DynamicCommands
@@ -18,8 +19,10 @@ class DynamicCommands extends AbstractCommands
      */
     public function runTasks()
     {
-        $command = $this->input()->getArgument('command');
-        $tasks = $this->getConfig()->get("commands.{$command}");
+        $commandName = $this->input()->getArgument('command');
+        /** @var \Consolidation\AnnotatedCommand\AnnotatedCommand $command */
+        $command = Robo::application()->get($commandName);
+        $tasks = $command->getAnnotationData()['tasks'];
 
         return $this->taskCollectionFactory($tasks);
     }

--- a/src/Commands/DynamicCommands.php
+++ b/src/Commands/DynamicCommands.php
@@ -6,9 +6,11 @@ use OpenEuropa\TaskRunner\Tasks as TaskRunnerTasks;
 use Robo\Robo;
 
 /**
- * Class DynamicCommands
+ * Command class for dynamic commands.
  *
- * @package OpenEuropa\TaskRunner\Commands
+ * Dynamic commands are defined in YAML and have no dedicated command class.
+ * A command is comprised of an array of tasks with their configuration.
+ * See the section in the README on dynamic commands for more information.
  */
 class DynamicCommands extends AbstractCommands
 {

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -241,8 +241,7 @@ class TaskRunner
      */
     private function registerDynamicCommands(Application $application)
     {
-        if (!$commands = $this->getConfig()->get('commands'))
-        {
+        if (!$commands = $this->getConfig()->get('commands')) {
             return;
         }
 
@@ -260,7 +259,7 @@ class TaskRunner
                 $aliases = $registeredCommand->getAliases();
                 // The dynamic command overrides an alias rather than a
                 // registered command main name. Get the command main name.
-                if (in_array($name, $aliases, TRUE)) {
+                if (in_array($name, $aliases, true)) {
                     $name = $registeredCommand->getName();
                 }
             }

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -71,7 +71,6 @@ class TaskRunner
     private $defaultCommandClasses = [
         ChangelogCommands::class,
         DrupalCommands::class,
-        DynamicCommands::class,
         ReleaseCommands::class,
     ];
 
@@ -250,6 +249,7 @@ class TaskRunner
         /** @var \Consolidation\AnnotatedCommand\AnnotatedCommandFactory $commandFactory */
         $commandFactory = $this->container->get('commandFactory');
         $commandFileName = DynamicCommands::class."Commands";
+        $this->runner->registerCommandClass($this->application, DynamicCommands::class);
         $commandClass = $this->container->get($commandFileName);
 
         foreach ($commands as $name => $tasks) {

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -248,6 +248,7 @@ class TaskRunner
             $commandClass = $this->container->get($commandFileName);
             $commandFactory = $this->container->get('commandFactory');
             $commandInfo = $commandFactory->createCommandInfo($commandClass, 'runTasks');
+            $commandInfo->addAnnotation('tasks', $tasks);
             $command = $commandFactory->createCommand($commandInfo, $commandClass)->setName($name);
             $application->add($command);
         }

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -105,8 +105,8 @@ class TaskRunner
      */
     public function run()
     {
-        // Discover early the commands to allow the dynamic commands overrides.
-        $commandClasses = $this->discoverCommandClasses('TaskRunner');
+        // Discover early the commands to allow dynamic command overrides.
+        $commandClasses = $this->discoverCommandClasses();
         $commandClasses = array_merge($this->defaultCommandClasses, $commandClasses);
 
         // Register command classes.
@@ -254,15 +254,13 @@ class TaskRunner
     }
 
     /**
-     * @param string $relativeNamespace
-     *
      * @return string[]
      */
-    protected function discoverCommandClasses($relativeNamespace)
+    protected function discoverCommandClasses()
     {
         /** @var \Robo\ClassDiscovery\RelativeNamespaceDiscovery $discovery */
         $discovery = Robo::service('relativeNamespaceDiscovery');
-        $discovery->setRelativeNamespace($relativeNamespace . '\Commands')
+        $discovery->setRelativeNamespace('TaskRunner\Commands')
             ->setSearchPattern('/.*Commands?\.php$/');
         return $discovery->getClasses();
     }

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -100,7 +100,20 @@ class TaskRunner
     }
 
     /**
+     * Executes the command that has been provided on the command line input.
+     *
+     * A command consists of multiple tasks and is defined either as a Command
+     * class in the `vendor\TaskRunner\Commands` subnamespace, or a dynamic
+     * command defined in "runner.yml".
+     *
+     * Robo is not architected in a way that makes it easily extensible. It has
+     * no events that we can hook into to allow it to discover our two custom
+     * types of commands. We work around this by registering our own commands on
+     * the container in the same way as is done by Robo, and then delegating to
+     * `\Robo\Runner::run()`.
+     *
      * @return int
+     *   The exit code returned by the command.
      */
     public function run()
     {
@@ -111,10 +124,12 @@ class TaskRunner
         // Register command classes.
         $this->runner->registerCommandClasses($this->application, $commandClasses);
 
-        // Register commands defined in runner.yml file.
+        // Register commands defined in runner.yml file. These are registered
+        // after the command classes so that dynamic commands can override
+        // commands defined in classes.
         $this->registerDynamicCommands($this->application);
 
-        // Run command.
+        // Run the command entered by the user in the CLI.
         return $this->runner->run($this->input, $this->output, $this->application);
     }
 
@@ -237,7 +252,15 @@ class TaskRunner
     }
 
     /**
+     * Registers dynamic commands in the container so Robo can find them.
+     *
+     * The standard class defined commands have already been registered at this
+     * point. If a dynamic command has the same identifier or alias as a class
+     * defined command it will replace it. This allows users to override
+     * existing commands in their runner.yml file.
+     *
      * @param \Robo\Application $application
+     *   The Robo Symfony application.
      */
     private function registerDynamicCommands(Application $application)
     {
@@ -247,6 +270,11 @@ class TaskRunner
 
         /** @var \Consolidation\AnnotatedCommand\AnnotatedCommandFactory $commandFactory */
         $commandFactory = $this->container->get('commandFactory');
+
+        // Robo registers command classes in the container using the qualified
+        // namespace with "Commands" appended to it. This results in identifiers
+        // like "OpenEuropa\TaskRunner\Commands\DrupalCommandsCommands".
+        // @see \Robo\Runner::instantiateCommandClass()
         $commandFileName = DynamicCommands::class."Commands";
         $this->runner->registerCommandClass($this->application, DynamicCommands::class);
         $commandClass = $this->container->get($commandFileName);
@@ -274,6 +302,12 @@ class TaskRunner
     }
 
     /**
+     * Discovers task runner commands that are provided by various packages.
+     *
+     * This traverses the namespace tree and returns all classes that are
+     * located in the source tree in the folder "TaskRunner/Commands/" and have
+     * a filename that ends with "*Command.php" or "*Commands.php".
+     *
      * @return string[]
      */
     protected function discoverCommandClasses()

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -242,11 +242,17 @@ class TaskRunner
      */
     private function registerDynamicCommands(Application $application)
     {
-        foreach ($this->getConfig()->get('commands', []) as $name => $tasks) {
-            /** @var \Consolidation\AnnotatedCommand\AnnotatedCommandFactory $commandFactory */
-            $commandFileName = DynamicCommands::class."Commands";
-            $commandClass = $this->container->get($commandFileName);
-            $commandFactory = $this->container->get('commandFactory');
+        if (!$commands = $this->getConfig()->get('commands'))
+        {
+            return;
+        }
+
+        /** @var \Consolidation\AnnotatedCommand\AnnotatedCommandFactory $commandFactory */
+        $commandFactory = $this->container->get('commandFactory');
+        $commandFileName = DynamicCommands::class."Commands";
+        $commandClass = $this->container->get($commandFileName);
+
+        foreach ($commands as $name => $tasks) {
             $commandInfo = $commandFactory->createCommandInfo($commandClass, 'runTasks');
             $commandInfo->addAnnotation('tasks', $tasks);
             $command = $commandFactory->createCommand($commandInfo, $commandClass)->setName($name);

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -253,9 +253,23 @@ class TaskRunner
         $commandClass = $this->container->get($commandFileName);
 
         foreach ($commands as $name => $tasks) {
+            $aliases = [];
+            // This command has been already registered as an annotated command.
+            if ($application->has($name)) {
+                $registeredCommand = $application->get($name);
+                $aliases = $registeredCommand->getAliases();
+                // The dynamic command overrides an alias rather than a
+                // registered command main name. Get the command main name.
+                if (in_array($name, $aliases, TRUE)) {
+                    $name = $registeredCommand->getName();
+                }
+            }
+
             $commandInfo = $commandFactory->createCommandInfo($commandClass, 'runTasks');
             $commandInfo->addAnnotation('tasks', $tasks);
-            $command = $commandFactory->createCommand($commandInfo, $commandClass)->setName($name);
+            $command = $commandFactory->createCommand($commandInfo, $commandClass)
+                ->setName($name)
+                ->setAliases($aliases);
             $application->add($command);
         }
     }

--- a/src/Tasks/CollectionFactory/CollectionFactory.php
+++ b/src/Tasks/CollectionFactory/CollectionFactory.php
@@ -95,7 +95,7 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
     protected function taskFactory($task)
     {
         if (is_string($task)) {
-            return $this->taskExec($task);
+            return $this->taskExec($task)->interactive($this->isTtySupported());
         }
 
         $this->secureOption($task, 'force', false);
@@ -196,5 +196,15 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
     protected function secureOption(array &$task, $name, $default)
     {
         $task[$name] = isset($task[$name]) ? $task[$name] : $default;
+    }
+
+    /**
+     * Checks if the TTY mode is supported
+     *
+     * @return bool
+     */
+    protected function isTtySupported()
+    {
+        return PHP_OS !== 'WINNT' && (bool) @proc_open('echo 1 >/dev/null', [['file', '/dev/tty', 'r'], ['file', '/dev/tty', 'w'], ['file', '/dev/tty', 'w']], $pipes);
     }
 }

--- a/src/Tasks/CollectionFactory/CollectionFactory.php
+++ b/src/Tasks/CollectionFactory/CollectionFactory.php
@@ -82,15 +82,23 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
     }
 
     /**
+     * Returns the Robo task for a given task definition.
+     *
+     * For the moment this is a hardcoded mapping of supported tasks.
+     *
      * @param array|string $task
+     *   A task definition array consisting of the task name and optionally a
+     *   number of configuration options. Can also be a string representing a
+     *   shell command.
      *
      * @return \Robo\Contract\TaskInterface
+     *   The Robo task.
      *
      * @throws \Robo\Exception\TaskException
      *
      * @SuppressWarnings(PHPMD)
      *
-     * @todo: Tuner this into a proper plugin system.
+     * @todo: Turn this into a proper plugin system.
      */
     protected function taskFactory($task)
     {
@@ -98,6 +106,10 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
             return $this->taskExec($task)->interactive($this->isTtySupported());
         }
 
+        // Set a number of options to safe defaults if they have not been given
+        // a different value in the task definition.
+        // @todo Not all of these options apply to all available tasks. Only
+        //   set defaults for this task's options.
         $this->secureOption($task, 'force', false);
         $this->secureOption($task, 'umask', 0000);
         $this->secureOption($task, 'recursive', false);
@@ -187,11 +199,16 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
     }
 
     /**
-     * Secure option value.
+     * Sets the given safe default value for the option with the given name.
+     *
+     * If the option is already set it will not be overwritten.
      *
      * @param array  $task
+     *   The task array containing the task name and configuration.
      * @param string $name
+     *   The name of the option for which to provide a safe default value.
      * @param mixed  $default
+     *   The default value.
      */
     protected function secureOption(array &$task, $name, $default)
     {

--- a/src/Tasks/ProcessConfigFile/loadTasks.php
+++ b/src/Tasks/ProcessConfigFile/loadTasks.php
@@ -10,8 +10,12 @@ namespace OpenEuropa\TaskRunner\Tasks\ProcessConfigFile;
 trait loadTasks
 {
     /**
-     * @param $source
-     * @param $destination
+     * Replaces placeholders with actual values.
+     *
+     * @param string $source
+     *   The path to the file to process.
+     * @param string $destination
+     *   The path where to store the processed file.
      *
      * @return \OpenEuropa\TaskRunner\Tasks\ProcessConfigFile\ProcessConfigFile
      */

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -391,10 +391,13 @@ EOF;
         $input = new StringInput("{$command} --working-dir=".$this->getSandboxRoot());
         $output = new BufferedOutput();
         $runner = new TaskRunner($input, $output, $this->getClassLoader());
-        $runner->run();
+        $exit_code = $runner->run();
+
+        // Check that the command succeeded, i.e. has exit code 0.
+        $this->assertEquals(0, $exit_code);
+
         // Check that the output is as expected.
         $text = $output->fetch();
-
         foreach ($expected as $row) {
             $this->assertContains($row, $text);
         }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -370,6 +370,29 @@ EOF;
     }
 
     /**
+     * @dataProvider overrideCommandDataProvider
+     *
+     * @param $command
+     * @param array $runnerConfig
+     * @param array $expected
+     */
+    public function testOverrideCommand($command, array $runnerConfig, array $expected)
+    {
+        $runnerConfigFile = $this->getSandboxFilepath('runner.yml');
+        file_put_contents($runnerConfigFile, Yaml::dump($runnerConfig));
+
+        $input = new StringInput("{$command} --working-dir=".$this->getSandboxRoot());
+        $output = new BufferedOutput();
+        $runner = new TaskRunner($input, $output, $this->getClassLoader());
+        $runner->run();
+        $text = $output->fetch();
+
+        foreach ($expected as $row) {
+            $this->assertContains($row, $text);
+        }
+    }
+
+    /**
      * @return array
      */
     public function simulationDataProvider()
@@ -423,6 +446,14 @@ EOF;
     public function changelogDataProvider()
     {
         return $this->getFixtureContent('changelog.yml');
+    }
+
+    /**
+     * @return array
+     */
+    public function overrideCommandDataProvider()
+    {
+        return $this->getFixtureContent('override.yml');
     }
 
     /**

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -370,11 +370,18 @@ EOF;
     }
 
     /**
+     * Tests that existing commands can be overridden in the runner config.
+     *
      * @dataProvider overrideCommandDataProvider
      *
-     * @param $command
+     * @param string $command
+     *   A command that will be executed by the task runner.
      * @param array $runnerConfig
+     *   An array of task runner configuration data, equivalent to what would be
+     *   written in a "runner.yml" file. This contains the overridden commands.
      * @param array $expected
+     *   An array of strings which are expected to be output to the terminal
+     *   during execution of the command.
      */
     public function testOverrideCommand($command, array $runnerConfig, array $expected)
     {
@@ -385,6 +392,7 @@ EOF;
         $output = new BufferedOutput();
         $runner = new TaskRunner($input, $output, $this->getClassLoader());
         $runner->run();
+        // Check that the output is as expected.
         $text = $output->fetch();
 
         foreach ($expected as $row) {
@@ -449,9 +457,20 @@ EOF;
     }
 
     /**
+     * Provides test cases for ::testOverrideCommand().
+     *
      * @return array
+     *   An array of test cases, each one an array with the following keys:
+     *   - 'command': A string representing a command that will be executed by
+     *     the task runner.
+     *   - 'runnerConfig': An array of task runner configuration data,
+     *     equivalent to what would be written in a "runner.yml" file.
+     *   - 'expected': An array of strings which are expected to be output to
+     *     the terminal during execution of the command.
+     *
+     * @see \OpenEuropa\TaskRunner\Tests\Commands\CommandsTest::testOverrideCommand()
      */
-    public function overrideCommandDataProvider()
+    public function overrideCommandDataProvider(): array
     {
         return $this->getFixtureContent('override.yml');
     }

--- a/tests/fixtures/override.yml
+++ b/tests/fixtures/override.yml
@@ -1,0 +1,46 @@
+# Override a default command by its main name.
+# Run command by its main name.
+- command: drupal:site-install
+  runnerConfig:
+    commands:
+      drupal:site-install:
+        - echo "Hello world!"
+        - echo "Hey you!"
+  expected:
+    - '[Exec] Running echo "Hello world!"'
+    - '[Exec] Running echo "Hey you!"'
+
+# Override a default command by its main name.
+# Run command by one of its aliases.
+- command: drupal:site-install
+  runnerConfig:
+    commands:
+      dsi:
+        - echo "Hello world!"
+        - echo "Hey you!"
+  expected:
+    - '[Exec] Running echo "Hello world!"'
+    - '[Exec] Running echo "Hey you!"'
+
+# Override a default command by one of its aliases.
+# Run command by other alias.
+- command: drupal:si
+  runnerConfig:
+    commands:
+      dsi:
+        - echo "Hello world!"
+        - echo "Hey you!"
+  expected:
+    - '[Exec] Running echo "Hello world!"'
+    - '[Exec] Running echo "Hey you!"'
+
+# Override a custom command.
+- command: custom:command-two
+  runnerConfig:
+    commands:
+      custom:command-two:
+        - echo "Hello world!"
+        - echo "Hey you!"
+  expected:
+    - '[Exec] Running echo "Hello world!"'
+    - '[Exec] Running echo "Hey you!"'


### PR DESCRIPTION
## MULTISITE-23486

### Description

Right now, a dynamic command can override a default commands, such as `drupal:site-install` or `release:create-archive`. But it cannot override commands provided by 3rd party, such as `ec-europa/toolkit`. The reason is that such commands are discovered after discovering dynamic commands, in `\Robo\Runner::run()`.

This PR swaps the order by discovering and registering the 3rd party commands before registering dynamic commands, so that a command provided in `runner.yml` will override an class annotated command.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands


