### PR TITLE
Instructions in README cause root owned files to appear in the local filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker-compose exec web ./vendor/bin/grumphp run
 To run the phpunit tests:
 
 ```bash
-docker-compose exec web ./vendor/bin/phpunit
+docker-compose exec --user=$(id -u):$(id -g) web ./vendor/bin/phpunit
 ```
 
 ## Configuration


### PR DESCRIPTION
## ISAICP-5825

### Description

When running tests according to the instructions in the README the user ends up with a bunch of root-owned files that are created during the tests.

Let's update the README with safe instructions so that a potential bug in a test will not accidentally overwrite critical files.

### Change log

- Fixed: README updated with instructions on how to safely run the unit tests
