### PR TITLE
Default to safe permissions when creating folders

### DIFF
--- a/src/Tasks/CollectionFactory/CollectionFactory.php
+++ b/src/Tasks/CollectionFactory/CollectionFactory.php
@@ -103,7 +103,7 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
         $this->secureOption($task, 'recursive', false);
         $this->secureOption($task, 'time', time());
         $this->secureOption($task, 'atime', time());
-        $this->secureOption($task, 'mode', 0777);
+        $this->secureOption($task, 'mode', 0755);
 
         switch ($task['task']) {
             case "mkdir":


### PR DESCRIPTION
## ISAICP-5825

### Description

Currently any command that uses the `mkdir` task without specifying their own permissions will cause the folder to be created with full read and write permissions for any user on the system. This is not safe on servers with shared access. Let's default to `755` instead which will prevent other users from writing to our folders by default.

### Change log

- Security: Default to 755 permission when creating folders
