### PR TITLE
ISAICP-5988: Command config cannot be overridden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ behat.yml
 /.idea/
 runner.yml
 docker-compose.*.yml
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ docker-compose exec web ./vendor/bin/phpunit
 
 ## Configuration
 
+Task Runner provides a useful command (`config`) that allows inspecting and
+debugging the configuration. To find out how can be used, run:
+
+```bash
+./vendor/bin/run config --help
+```
+
 Task Runner commands can be customized in two ways:
 
 1. By setting arguments and options when running a command.

--- a/src/Commands/AbstractCommands.php
+++ b/src/Commands/AbstractCommands.php
@@ -12,8 +12,6 @@ use Robo\Contract\ConfigAwareInterface;
 use Robo\Contract\IOAwareInterface;
 use Robo\Exception\TaskException;
 use Robo\LoadAllTasks;
-use Robo\Robo;
-use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**
@@ -35,18 +33,6 @@ abstract class AbstractCommands implements BuilderAwareInterface, IOAwareInterfa
     public function getConfigurationFile()
     {
         return __DIR__ . '/../../config/commands/base.yml';
-    }
-
-    /**
-     * Command initialization.
-     *
-     * @param \Symfony\Component\Console\Event\ConsoleCommandEvent $event
-     *
-     * @hook pre-command-event *
-     */
-    public function initializeRuntimeConfiguration(ConsoleCommandEvent $event)
-    {
-        Robo::loadConfiguration([$this->getConfigurationFile()], $this->getConfig());
     }
 
     /**

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -8,6 +8,8 @@ use Composer\Autoload\ClassLoader;
 use Consolidation\AnnotatedCommand\Parser\Internal\DocblockTag;
 use Consolidation\AnnotatedCommand\Parser\Internal\TagFactory;
 use Consolidation\Config\Loader\ConfigProcessor;
+use Consolidation\Config\Loader\YamlConfigLoader;
+use Dflydev\DotAccessData\Util;
 use Gitonomy\Git\Repository;
 use League\Container\ContainerAwareTrait;
 use OpenEuropa\TaskRunner\Commands\ChangelogCommands;
@@ -105,7 +107,7 @@ class TaskRunner
             $classLoader
         );
 
-        $this->createConfiguration();
+        $this->prepareConfiguration();
 
         // Create and initialize runner.
         $this->runner = new RoboRunner();
@@ -130,6 +132,16 @@ class TaskRunner
      */
     public function run()
     {
+        $this->prepareApplication();
+        // Run the command entered by the user in the CLI.
+        return $this->runner->run($this->input, $this->output, $this->application);
+    }
+
+    /**
+     * Register all commands and prepares the configuration.
+     */
+    private function prepareApplication(): void
+    {
         // Discover early the commands to allow dynamic command overrides.
         $commandClasses = $this->discoverCommandClasses();
         $commandClasses = array_merge($this->defaultCommandClasses, $commandClasses);
@@ -137,13 +149,17 @@ class TaskRunner
         // Register command classes.
         $this->runner->registerCommandClasses($this->application, $commandClasses);
 
+        // At this point we are ready to add the configuration provided by
+        // providers on top of commands default config and process them. It's
+        // important to do the processing here as the in the next step, in order
+        // to register dynamic commands, we need the full configuration to be
+        // already processed/resolved and tokens replaced.
+        $this->processConfiguration($commandClasses);
+
         // Register commands defined in runner.yml file. These are registered
         // after the command classes so that dynamic commands can override
         // commands defined in classes.
         $this->registerDynamicCommands($this->application);
-
-        // Run the command entered by the user in the CLI.
-        return $this->runner->run($this->input, $this->output, $this->application);
     }
 
     /**
@@ -163,9 +179,9 @@ class TaskRunner
     }
 
     /**
-     * Parses the configuration files, and merges them into the Config object.
+     * Gathers unprocessed configuration from all providers.
      */
-    private function createConfiguration()
+    private function prepareConfiguration(): void
     {
         $config = new Config();
         $config->set('runner.working_dir', realpath($this->workingDir));
@@ -175,11 +191,38 @@ class TaskRunner
             $class::provide($config);
         }
 
-        // Resolve variables and import into config.
-        $processor = (new ConfigProcessor())->add($config->export());
-        $this->config->import($processor->export());
+        $this->config->replace($config->export());
+    }
+
+    /**
+     * Merges commands default configuration and processes tokens.
+     *
+     * @param string[] $commandClasses
+     */
+    private function processConfiguration(array $commandClasses): void
+    {
+        $loader = new YamlConfigLoader();
+        $configArray = [];
+
+        foreach ($commandClasses as $commandClass) {
+            // Commands were already registered as container services and
+            // instantiated, in \Robo\Runner::instantiateCommandClass().
+            // @see \Robo\Runner::instantiateCommandClass()
+            $serviceId = "{$commandClass}Commands";
+            /** @var \OpenEuropa\TaskRunner\Commands\AbstractCommands $command */
+            $command = $this->getContainer()->get($serviceId);
+            $file = $command->getConfigurationFile();
+            $configFromFile = file_exists($file) ? $loader->load($file)->export() : [];
+            $configArray = Util::mergeAssocArray($configArray, $configFromFile);
+        }
+
+        // Command default configs come first to allow overrides from providers.
+        $configArray = Util::mergeAssocArray($configArray, $this->getConfig()->export());
+        $processor = (new ConfigProcessor())->add($configArray);
+        $this->getConfig()->replace($processor->export());
+
         // Keep the container in sync.
-        $this->container->add('config', $this->config);
+        $this->getContainer()->add('config', $this->getConfig());
     }
 
     /**

--- a/src/TaskRunner.php
+++ b/src/TaskRunner.php
@@ -169,9 +169,15 @@ class TaskRunner
      *
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
+     *
+     * @deprecated in openeuropa/task-runner:2.0.0-alpha3 removed from
+     *   openeuropa/task-runner:2.0.0. No replacements are provided as it has
+     *   been used only in tests.
      */
     public function getCommands($class)
     {
+        @trigger_error(__METHOD__ . '() is deprecated in openeuropa/task-runner:2.0.0-alpha3 removed from openeuropa/task-runner:2.0.0. No replacements are provided as it has been used only in tests.');
+
         // Register command classes.
         $this->runner->registerCommandClasses($this->application, $this->defaultCommandClasses);
 

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenEuropa\TaskRunner\Tests;
 
+use OpenEuropa\TaskRunner\Tests\Traits\TestingRunnerTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
@@ -13,6 +14,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 abstract class AbstractTest extends TestCase
 {
+    use TestingRunnerTrait;
+
     /**
      * @inheritDoc
      */

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -6,7 +6,7 @@ namespace OpenEuropa\TaskRunner\Tests;
 
 use OpenEuropa\TaskRunner\Commands\ChangelogCommands;
 use OpenEuropa\TaskRunner\TaskRunner;
-use OpenEuropa\TaskRunner\Tests\AbstractTest;
+use Robo\Robo;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -111,9 +111,9 @@ class CommandsTest extends AbstractTest
      */
     public function testChangelogCommands(array $options, $expected)
     {
-        $runner = new TaskRunner(new StringInput(''), new NullOutput(), $this->getClassLoader());
-        /** @var ChangelogCommands $commands */
-        $commands = $runner->getCommands(ChangelogCommands::class);
+        $this->getTestingRunner(new StringInput(''), new NullOutput(), $this->getClassLoader());
+        /** @var ChangelogCommands $command */
+        $commands = Robo::getContainer()->get(ChangelogCommands::class . 'Commands');
         $this->assertEquals($expected, $commands->generateChangelog($options)->getCommand());
     }
 
@@ -354,7 +354,7 @@ EOF;
 
         // Create a new runner.
         $input = new StringInput('list --working-dir=' . $this->getSandboxRoot());
-        $runner = new TaskRunner($input, new NullOutput(), $this->getClassLoader());
+        $runner = $this->getTestingRunner($input, new NullOutput(), $this->getClassLoader());
 
         // Set as `build` by `config/runner.yml`.
         // Overwritten as `drupal` by `tests/fixtures/userconfig.yml`.

--- a/tests/Tasks/ProcessConfigFileTest.php
+++ b/tests/Tasks/ProcessConfigFileTest.php
@@ -7,6 +7,8 @@ namespace OpenEuropa\TaskRunner\Tests\Tasks;
 use OpenEuropa\TaskRunner\Tasks\ProcessConfigFile\ProcessConfigFile;
 use OpenEuropa\TaskRunner\Tasks\ProcessConfigFile\loadTasks;
 use OpenEuropa\TaskRunner\Tests\AbstractTaskTest;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -29,7 +31,15 @@ class ProcessConfigFileTest extends AbstractTaskTest
         $source = $this->getSandboxFilepath('source.yml');
         $destination = $this->getSandboxFilepath('destination.yml');
         file_put_contents($source, Yaml::dump($data));
-        $this->taskProcessConfigFile($source, $destination)->run();
+
+        $runner = $this->getTestingRunner(new StringInput(''), new NullOutput(), $this->getClassLoader());
+        /** @var \OpenEuropa\TaskRunner\Tasks\ProcessConfigFile\ProcessConfigFile $processConfigFileTask */
+        $processConfigFileTask = $this->taskProcessConfigFile($source, $destination);
+        // Configuration of $runner is already prepared. Use it.
+        // @see \OpenEuropa\TaskRunner\Tests\Traits\RunnerTrait::getTestingRunner()
+        $processConfigFileTask->getConfig()->replace($runner->getConfig()->export());
+        $processConfigFileTask->run();
+
         $destinationData = Yaml::parse(file_get_contents($destination));
         $this->assertEquals($expected, $destinationData);
     }

--- a/tests/Traits/TestingRunnerTrait.php
+++ b/tests/Traits/TestingRunnerTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEuropa\TaskRunner\Tests\Traits;
+
+use Composer\Autoload\ClassLoader;
+use OpenEuropa\TaskRunner\TaskRunner;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait TestingRunnerTrait
+{
+    /**
+     * Returns a task runner having the configuration already processed.
+     *
+     * The configuration is gathered from config provider classes and applied on
+     * top of commands default configuration. The replacement of tokens is only
+     * processed at runtime. This method forces the config token replacements in
+     * order to make the full processed configuration available for tests.
+     *
+     * @param \Symfony\Component\Console\Input\InputInterface   $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \Composer\Autoload\ClassLoader                    $classLoader
+     *
+     * @return \OpenEuropa\TaskRunner\TaskRunner
+     */
+    protected function getTestingRunner(InputInterface $input, OutputInterface $output, ClassLoader $classLoader): TaskRunner
+    {
+        $taskRunner = new TaskRunner($input, $output, $classLoader);
+        $prepareConfigMethod = new \ReflectionMethod($taskRunner, 'prepareApplication');
+        $prepareConfigMethod->setAccessible(TRUE);
+        $prepareConfigMethod->invoke($taskRunner);
+        return $taskRunner;
+    }
+}

--- a/tests/Traits/TestingRunnerTrait.php
+++ b/tests/Traits/TestingRunnerTrait.php
@@ -9,6 +9,9 @@ use OpenEuropa\TaskRunner\TaskRunner;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Reusable code used in tests.
+ */
 trait TestingRunnerTrait
 {
     /**
@@ -29,7 +32,7 @@ trait TestingRunnerTrait
     {
         $taskRunner = new TaskRunner($input, $output, $classLoader);
         $prepareConfigMethod = new \ReflectionMethod($taskRunner, 'prepareApplication');
-        $prepareConfigMethod->setAccessible(TRUE);
+        $prepareConfigMethod->setAccessible(true);
         $prepareConfigMethod->invoke($taskRunner);
         return $taskRunner;
     }

--- a/tests/custom/src/TaskRunner/Commands/FirstCustomCommands.php
+++ b/tests/custom/src/TaskRunner/Commands/FirstCustomCommands.php
@@ -12,6 +12,14 @@ use OpenEuropa\TaskRunner\Commands\AbstractCommands;
 class FirstCustomCommands extends AbstractCommands
 {
     /**
+     * {@inheritdoc}
+     */
+    public function getConfigurationFile(): string
+    {
+        return __DIR__ . '/config/config.yml';
+    }
+
+    /**
      * @command custom:command-one
      */
     public function commandOne()

--- a/tests/custom/src/TaskRunner/Commands/config/config.yml
+++ b/tests/custom/src/TaskRunner/Commands/config/config.yml
@@ -1,0 +1,3 @@
+command_config__not_overridden: 10
+command_config__overridden_by_3rd_party_provider: 100
+command_config__overridden_by_runner_yml: 1000

--- a/tests/fixtures/commands/drupal-drush-setup.yml
+++ b/tests/fixtures/commands/drupal-drush-setup.yml
@@ -30,3 +30,21 @@
     - file: "build/sites/default/drushrc.php"
       contains: "$options[\"uri\"] = 'http://web';"
       not_contains: "ignored-directories"
+
+- configuration:
+    drupal:
+      drush:
+        options:
+          uri: "http://web"
+    command:
+      drupal:
+        drush-setup:
+          options:
+            config-dir: ${drupal.root}/..
+  expected:
+    - file: "drush/drush.yml"
+      contains: "uri: 'http://web'"
+      not_contains: ~
+    - file: "build/sites/default/drushrc.php"
+      contains: "$options[\"uri\"] = 'http://web';"
+      not_contains: "ignored-directories"

--- a/tests/fixtures/commands/drupal-drush-setup.yml
+++ b/tests/fixtures/commands/drupal-drush-setup.yml
@@ -42,7 +42,7 @@
           options:
             config-dir: ${drupal.root}/..
   expected:
-    - file: "drush/drush.yml"
+    - file: "drush.yml"
       contains: "uri: 'http://web'"
       not_contains: ~
     - file: "build/sites/default/drushrc.php"

--- a/tests/fixtures/third_party.yml
+++ b/tests/fixtures/third_party.yml
@@ -5,3 +5,7 @@ foo: bar
 # Should be 'is-baz' as the variables should be resolved only at the end, when
 # all config providers had the chance to provide token values.
 qux: is-${foo}
+
+# Overrides the command default config.
+command_config__overridden_by_3rd_party_provider: 200
+command_config__overridden_by_runner_yml: 2000


### PR DESCRIPTION
## ISAICP-5988

### Description

Each command class is able load configuration from a file by implementing `AbstractCommands::getConfigurationFile()` and returning a hardcoded file path. The method's docblock states:

```
/**
 * Path to YAML configuration file containing command defaults.
 */
```

But, unfortunately, these are not defaults because they cannot be overridden. Instead, the runner.yml.dist and runner.yml configs are overridden by values from the `AbstractCommands::getConfigurationFile()` file.

The first commit (1a4a840) of this PR proves the bug.

### Proposal

* Don't process early the tokens.
* After commands from classes were discovered, merge config providers configuration on top of default configuration provided by commands and process the replacements.
* This should happen before the dynamic commands discovery and that discovery should benefit from the whole processed configuration.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

N/A
