### PR TITLE
ISAICP-5989: Tokens containing digits are not supported

### DIFF
--- a/src/Traits/ConfigurationTokensTrait.php
+++ b/src/Traits/ConfigurationTokensTrait.php
@@ -21,7 +21,7 @@ trait ConfigurationTokensTrait
      */
     protected function extractRawTokens($text)
     {
-        preg_match_all('/\$\{(([A-Za-z_\-]+\.?)+)\}/', $text, $matches);
+        preg_match_all('/\${(([A-Za-z]([A-Za-z0-9_\-]+)?\.?)+)}/', $text, $matches);
         if (isset($matches[0]) && !empty($matches[0]) && is_array($matches[0])) {
             return array_combine($matches[0], $matches[1]);
         }

--- a/tests/ConfigurationTokensTest.php
+++ b/tests/ConfigurationTokensTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenEuropa\TaskRunner\Tests;
+
+use My\Custom\TestConfigurationTokensTraitWrapper;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests configuration tokens.
+ *
+ * @coversDefaultClass \OpenEuropa\TaskRunner\Traits\ConfigurationTokensTrait
+ */
+class ConfigurationTokensTest extends TestCase
+{
+
+    /**
+     * @param string $text
+     * @param string[] $expectedTokens
+     * @covers ::extractRawTokens
+     * @dataProvider extractRawTokensDataProvider
+     */
+    public function testExtractRawTokens(string $text, array $expectedTokens): void
+    {
+        $class = new \ReflectionClass(TestConfigurationTokensTraitWrapper::class);
+        $method = $class->getMethod('extractRawTokens');
+        $method->setAccessible(true);
+        $actualTokens = array_keys(
+            $method->invoke(new TestConfigurationTokensTraitWrapper(), $text)
+        );
+        $this->assertSame($expectedTokens, $actualTokens);
+    }
+
+    /**
+     * @return array
+     */
+    public function extractRawTokensDataProvider(): array
+    {
+        return [
+            'simple' => [
+                '${foo.bar.baz} lore {ipsum}...${to.ke.n}',
+                ['${foo.bar.baz}', '${to.ke.n}'],
+            ],
+            'element with single char' => [
+                '${foo.b.baz}',
+                ['${foo.b.baz}']
+            ],
+            'with digits' => [
+                '${foo1.ba2r5.baz22}',
+                ['${foo1.ba2r5.baz22}'],
+            ],
+            'no digits as 1st char' => [
+                '${1foo.bar.baz} ${1foo.2bar.3baz}',
+                [],
+            ],
+            'forbidden chars' => [
+                '${foo!@#$%^&*.bar.baz} ${fo-o.b_Ar.ba--z3}',
+                ['${fo-o.b_Ar.ba--z3}'],
+            ],
+        ];
+    }
+}

--- a/tests/custom/src/TestConfigurationTokensTraitWrapper.php
+++ b/tests/custom/src/TestConfigurationTokensTraitWrapper.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace My\Custom;
+
+use OpenEuropa\TaskRunner\Traits\ConfigurationTokensTrait;
+
+/**
+ * Allows access to ConfigurationTokensTrait trait.
+ *
+ * @see \OpenEuropa\TaskRunner\Tests\ConfigurationTokensTest
+ */
+class TestConfigurationTokensTraitWrapper
+{
+    use ConfigurationTokensTrait;
+}


### PR DESCRIPTION
## ISAICP-5989

### Description

Tokens containing digits are not supported when processing a file.

