### PR TITLE
Make config sources (drupal.drush, drupal.settings) configurable

### DIFF
--- a/src/Commands/AbstractDrupalCommands.php
+++ b/src/Commands/AbstractDrupalCommands.php
@@ -314,7 +314,7 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
         'root' => InputOption::VALUE_REQUIRED,
         'config-dir' => InputOption::VALUE_REQUIRED,
         'config-source' => InputOption::VALUE_REQUIRED,
-        'fail-on-missing' => false,
+        'fail-on-missing' => true,
     ])
     {
         $config = $this->getConfig();

--- a/src/Commands/AbstractDrupalCommands.php
+++ b/src/Commands/AbstractDrupalCommands.php
@@ -300,8 +300,11 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
      *
      * @command drupal:drush-setup
      *
-     * @option root         Drupal root.
-     * @option config-dir   Directory where to store Drush 9 configuration file.
+     * @option root                    Drupal root.
+     * @option config-dir              Directory where to store Drush 9 configuration file.
+     * @option config-source           Config path of drush settings to write.
+     * @default config-source          drupal.drush
+     * @option fail-on-missing         Fail on missing config-source.
      *
      * @param array $options
      *
@@ -310,14 +313,21 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
     public function drushSetup(array $options = [
         'root' => InputOption::VALUE_REQUIRED,
         'config-dir' => InputOption::VALUE_REQUIRED,
+        'config-source' => InputOption::VALUE_REQUIRED,
+        'fail-on-missing' => false,
     ])
     {
         $config = $this->getConfig();
-        $yaml = Yaml::dump($config->get('drupal.drush'));
+        $config_source = $options['config-source'];
+        if (!$config->has($config_source) && !$options['fail-on-missing']) {
+            // Add missing config so taskWriteConfiguration won't throw.
+            $config->set($config_source, []);
+        }
+        $yaml = Yaml::dump($config->get($config_source));
 
         return $this->collectionBuilder()->addTaskList([
             $this->taskWriteConfiguration($options['root'] . '/sites/default/drushrc.php', $config)
-                ->setConfigKey('drupal.drush'),
+                ->setConfigKey($config_source),
             $this->taskWriteToFile($options['config-dir'] . '/drush.yml')->text($yaml),
         ]);
     }
@@ -348,6 +358,9 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
      * @option root                     Drupal root.
      * @option sites-subdir             Drupal site subdirectory.
      * @option settings-override-file   Drupal site settings override filename.
+     * @option config-source            Config path of contents to write.
+     * @default config-source           drupal.settings
+     * @option fail-on-missing          Fail on missing config-source.
      * @option force                    Drupal force generation of a new settings.php.
      * @option skip-permissions-setup   Drupal skip permissions setup.
      *
@@ -359,6 +372,8 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
         'root' => InputOption::VALUE_REQUIRED,
         'sites-subdir' => InputOption::VALUE_REQUIRED,
         'settings-override-file' => InputOption::VALUE_REQUIRED,
+        'config-source' => InputOption::VALUE_REQUIRED,
+        'fail-on-missing' => true,
         'force' => false,
         'skip-permissions-setup' => false,
     ])
@@ -381,10 +396,16 @@ abstract class AbstractDrupalCommands extends AbstractCommands implements Filesy
             $collection[] = $this->taskFilesystemStack()->copy($settings_default_path, $settings_path, true);
         }
 
+        $config = $this->getConfig();
+        $config_source = $options['config-source'];
+        if (!$config->has($config_source) && !$options['fail-on-missing']) {
+            // Add missing config so taskWriteConfiguration won't throw.
+            $config->set($config_source, []);
+        }
         $collection[] = $this->taskWriteConfiguration(
             $settings_override_path,
             $this->getConfig()
-        )->setConfigKey('drupal.settings');
+        )->setConfigKey($config_source);
 
         if (!$options['skip-permissions-setup']) {
             $collection[] = $this->permissionsSetup($options);


### PR DESCRIPTION
## OPENEUROPA-XXX

### Description

We're doing deployment with variable *drupal.settings* config sources (like *deploy.target.FOO.settings*).

### Change log

- Added:
  - Make drupal.drush configurable
  - Make drupal.settings configurable
  - Make (throw-if-missing) configurable

### Commands

```sh
$ vendor/bin/run help drupal:drush-setup
Description:
  Write Drush configuration files to given directories.

Usage:
  drupal:drush-setup [options]

Options:
      --root=ROOT                          Drupal root. [default: "web"]
      --config-dir=CONFIG-DIR              Directory where to store Drush 9 configuration file. [default: "web/drush"]
      --config-source[=CONFIG-SOURCE]      Config path of drush settings to write. [default: "drupal.drush"]
      --fail-on-missing[=FAIL-ON-MISSING]  Fail on missing config-source. [default: true]
      --no-fail-on-missing                 Negate --fail-on-missing option.
 ...


$ vendor/bin/run help drupal:settings-setup
Description:
  Setup Drupal settings overrides.

Usage:
  drupal:settings-setup [options]

Options:
      --root=ROOT                                      Drupal root. [default: "web"]
      --sites-subdir=SITES-SUBDIR                      Drupal site subdirectory. [default: "default"]
      --settings-override-file=SETTINGS-OVERRIDE-FILE  Drupal site settings override filename. [default: "settings.override.php"]
      --config-source[=CONFIG-SOURCE]                  Config path of contents to write. [default: "drupal.settings"]
      --fail-on-missing[=FAIL-ON-MISSING]              Fail on missing config-source. [default: true]
      --force                                          Drupal force generation of a new settings.php.
      --skip-permissions-setup                         Drupal skip permissions setup.
      --no-fail-on-missing                             Negate --fail-on-missing option.
  ...

```

