### PR TITLE
Add RunInCurrentProcess task and enable in CollectionFactory, fixes #142, obsoletes #125

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,15 @@ commands:
     - { task: "symlink", from: "../../custom/themes", to: "${drupal.root}/themes/custom" }
     - { task: "run", command: "drupal:drush-setup" }
     - { task: "run", command: "drupal:settings-setup" }
-    - { task: "run", command: "setup:behat" }
+    - { task: "run", command: "setup:behat", "in-current-process": true }
     - "./vendor/bin/drush --root=$(pwd)/${drupal.root} cr"
   setup:behat:
     - { task: "process", source: "behat.yml.dist", destination: "behat.yml" }
 ```
 
 Commands can reference each-other, allowing for complex scenarios to be implemented with relative ease.
+
+In this example, the `setup:behat` task will be executed in the current process, while the other tasks run in a new runner instance launched via command line.
 
 At the moment the following tasks are supported (optional argument default values in parenthesis):
 
@@ -211,7 +213,7 @@ At the moment the following tasks are supported (optional argument default value
 | `process-php` | `taskAppendConfiguration()`  | `type: append`, `config`, `source`, `destination`, `override` (false) |
 | `process-php` | `taskPrependConfiguration()` | `type: prepend`, `config`, `source`, `destination`, `override` (false) |
 | `process-php` | `taskWriteConfiguration()`   | `type: write`, `config`, `source`, `destination`, `override` (false) |
-| `run`         | `taskExec()`                 | `command`, `arguments`, `options` (will run `./vendor/bin/run [command] [argument1] [argument2] ... --[option1]=[value1] --[option2]=[value2] ...`) |
+| `run`         | `taskExec()`                 | `command`, `arguments`, `options` (will run `./vendor/bin/run [command] [argument1] [argument2] ... --[option1]=[value1] --[option2]=[value2] ...`), `in-current-process` (false) |
 
 Tasks provided as plain-text strings will be executed as is in the current working directory.
 

--- a/src/Tasks/CollectionFactory/CollectionFactory.php
+++ b/src/Tasks/CollectionFactory/CollectionFactory.php
@@ -19,6 +19,7 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
 {
     use LoadAllTasks;
     use TaskRunner\Tasks\ProcessConfigFile\loadTasks;
+    use TaskRunner\Tasks\RunInCurrentProcess\loadTasks;
     use \NuvoleWeb\Robo\Task\Config\Php\loadTasks;
 
     /**
@@ -166,9 +167,14 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
                 ]);
 
             case "run":
-                $taskExec = $this->taskExec($this->getConfig()->get('runner.bin_dir') . '/run')
-                    ->arg($task['command'])
-                    ->interactive($this->isTtySupported());
+                if (!empty($task['in-current-process'])) {
+                    $taskExec = $this->taskRunInCurrentProcess($task['command']);
+                }
+                else {
+                    $taskExec = $this->taskExec($this->getConfig()->get('runner.bin_dir') . '/run')
+                        ->arg($task['command'])
+                        ->interactive($this->isTtySupported());
+                }
                 if (!empty($task['arguments'])) {
                     $taskExec->args($task['arguments']);
                 }

--- a/src/Tasks/CollectionFactory/CollectionFactory.php
+++ b/src/Tasks/CollectionFactory/CollectionFactory.php
@@ -168,11 +168,13 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
 
             case "run":
                 if (!empty($task['in-current-process'])) {
-                    $taskExec = $this->taskRunInCurrentProcess($task['command']);
+                    $taskExec = $this->taskRunInCurrentProcess($task['command'])
+                      ->capture($task['capture'] ?? false);
                 }
                 else {
                     $taskExec = $this->taskExec($this->getConfig()->get('runner.bin_dir') . '/run')
                         ->arg($task['command'])
+                        ->printOutput(!($task['capture'] ?? false))
                         ->interactive($this->isTtySupported());
                 }
                 if (!empty($task['arguments'])) {
@@ -215,7 +217,9 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
                 return $this->collectionBuilder()->addTaskList($tasks);
 
             case 'exec':
-                $taskExec = $this->taskExec($task['command'])->interactive($this->isTtySupported());
+                $taskExec = $this->taskExec($task['command'])
+                    ->interactive($this->isTtySupported())
+                    ->printOutput(!($task['capture'] ?? false));
                 if (!empty($task['arguments'])) {
                     $taskExec->args($task['arguments']);
                 }

--- a/src/Tasks/CollectionFactory/CollectionFactory.php
+++ b/src/Tasks/CollectionFactory/CollectionFactory.php
@@ -168,13 +168,11 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
 
             case "run":
                 if (!empty($task['in-current-process'])) {
-                    $taskExec = $this->taskRunInCurrentProcess($task['command'])
-                      ->capture($task['capture'] ?? false);
+                    $taskExec = $this->taskRunInCurrentProcess($task['command']);
                 }
                 else {
                     $taskExec = $this->taskExec($this->getConfig()->get('runner.bin_dir') . '/run')
                         ->arg($task['command'])
-                        ->printOutput(!($task['capture'] ?? false))
                         ->interactive($this->isTtySupported());
                 }
                 if (!empty($task['arguments'])) {
@@ -217,9 +215,7 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
                 return $this->collectionBuilder()->addTaskList($tasks);
 
             case 'exec':
-                $taskExec = $this->taskExec($task['command'])
-                    ->interactive($this->isTtySupported())
-                    ->printOutput(!($task['capture'] ?? false));
+                $taskExec = $this->taskExec($task['command'])->interactive($this->isTtySupported());
                 if (!empty($task['arguments'])) {
                     $taskExec->args($task['arguments']);
                 }

--- a/src/Tasks/CollectionFactory/CollectionFactory.php
+++ b/src/Tasks/CollectionFactory/CollectionFactory.php
@@ -168,7 +168,8 @@ class CollectionFactory extends BaseTask implements BuilderAwareInterface, Simul
 
             case "run":
                 if (!empty($task['in-current-process'])) {
-                    $taskExec = $this->taskRunInCurrentProcess($task['command']);
+                    $taskExec = $this->taskRunInCurrentProcess($task['command'])
+                        ->setInheritConfig($task['inherit-config'] ?? false);
                 }
                 else {
                     $taskExec = $this->taskExec($this->getConfig()->get('runner.bin_dir') . '/run')

--- a/src/Tasks/RunInCurrentProcess/RunInCurrentProcess.php
+++ b/src/Tasks/RunInCurrentProcess/RunInCurrentProcess.php
@@ -4,6 +4,7 @@ namespace OpenEuropa\TaskRunner\Tasks\RunInCurrentProcess;
 
 use Consolidation\Config\ConfigInterface;
 use Robo\Common\CommandArguments;
+use Robo\Result;
 use Robo\Robo;
 use Robo\Runner as RoboRunner;
 use Robo\Task\BaseTask;
@@ -12,40 +13,41 @@ use Symfony\Component\Console\Input\StringInput;
 /**
  * Run a configurable command in current process.
  */
-class RunInCurrentProcess extends BaseTask {
+class RunInCurrentProcess extends BaseTask
+{
 
-  use CommandArguments;
+    use CommandArguments;
 
-  /**
-   * @var string
-   */
-  protected $command;
+    /**
+     * @var string
+     */
+    protected $command;
 
-  /**
-   * @param string $command
-   */
-  public function __construct(string $command)
-  {
-    $this->command = $command;
-  }
+    /**
+     * @param string $command
+     */
+    public function __construct(string $command)
+    {
+        $this->command = $command;
+    }
 
-  public function run() {
-    // Backup config, as command may change it.
-    $container = Robo::getContainer();
-    $config = $container->get('config');
-    assert($config instanceof ConfigInterface);
-    $configExport = $config->export();
+    public function run() {
+        // Backup config, as command may change it.
+        $container = Robo::getContainer();
+        $config = $container->get('config');
+        assert($config instanceof ConfigInterface);
+        $configExport = $config->export();
 
-    // Assemble and run command.
-    $line = trim($this->command . $this->arguments);
-    $input = new StringInput($line);
-    $runner = new RoboRunner();
-    $runner->setContainer($container);
-    $statusCode = $runner->run($input, Robo::output());
+        // Assemble and run command.
+        $line = trim($this->command . $this->arguments);
+        $input = new StringInput($line);
+        $runner = new RoboRunner();
+        $runner->setContainer($container);
+        $statusCode = $runner->run($input, Robo::output());
 
-    // Restore config.
-    $config->replace($configExport);
-    return $statusCode;
-  }
+        // Restore config.
+        $config->replace($configExport);
+        return $statusCode;
+    }
 
 }

--- a/src/Tasks/RunInCurrentProcess/RunInCurrentProcess.php
+++ b/src/Tasks/RunInCurrentProcess/RunInCurrentProcess.php
@@ -43,11 +43,11 @@ class RunInCurrentProcess extends BaseTask
         $input = new StringInput($line);
         $runner = new RoboRunner();
         $runner->setContainer($container);
-        $statusCode = $runner->run($input, Robo::output());
+        $exitCode = $runner->run($input, Robo::output());
 
         // Restore config.
         $config->replace($configExport);
-        return $statusCode;
+        return new Result($this, $exitCode);
     }
 
 }

--- a/src/Tasks/RunInCurrentProcess/RunInCurrentProcess.php
+++ b/src/Tasks/RunInCurrentProcess/RunInCurrentProcess.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OpenEuropa\TaskRunner\Tasks\RunInCurrentProcess;
+
+use Consolidation\Config\ConfigInterface;
+use Robo\Common\CommandArguments;
+use Robo\Robo;
+use Robo\Runner as RoboRunner;
+use Robo\Task\BaseTask;
+use Symfony\Component\Console\Input\StringInput;
+
+/**
+ * Run a configurable command in current process.
+ */
+class RunInCurrentProcess extends BaseTask {
+
+  use CommandArguments;
+
+  /**
+   * @var string
+   */
+  protected $command;
+
+  /**
+   * @param string $command
+   */
+  public function __construct(string $command)
+  {
+    $this->command = $command;
+  }
+
+  public function run() {
+    // Backup config, as command may change it.
+    $container = Robo::getContainer();
+    $config = $container->get('config');
+    assert($config instanceof ConfigInterface);
+    $configExport = $config->export();
+
+    // Assemble and run command.
+    $line = trim($this->command . $this->arguments);
+    $input = new StringInput($line);
+    $runner = new RoboRunner();
+    $runner->setContainer($container);
+    $statusCode = $runner->run($input, Robo::output());
+
+    // Restore config.
+    $config->replace($configExport);
+    return $statusCode;
+  }
+
+}

--- a/src/Tasks/RunInCurrentProcess/loadTasks.php
+++ b/src/Tasks/RunInCurrentProcess/loadTasks.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenEuropa\TaskRunner\Tasks\RunInCurrentProcess;
+
+/**
+ * Load run-in-current-process tasks.
+ */
+trait loadTasks {
+
+  /**
+   * @param string|\Robo\Contract\CommandInterface $command
+   *
+   * @return \Robo\Task\Base\Exec|\Robo\Collection\CollectionBuilder
+   */
+  public function taskRunInCurrentProcess($command) {
+    return $this->task(RunInCurrentProcess::class, $command);
+  }
+
+}

--- a/src/Tasks/RunInCurrentProcess/loadTasks.php
+++ b/src/Tasks/RunInCurrentProcess/loadTasks.php
@@ -5,15 +5,16 @@ namespace OpenEuropa\TaskRunner\Tasks\RunInCurrentProcess;
 /**
  * Load run-in-current-process tasks.
  */
-trait loadTasks {
+trait loadTasks
+{
 
-  /**
-   * @param string|\Robo\Contract\CommandInterface $command
-   *
-   * @return \Robo\Task\Base\Exec|\Robo\Collection\CollectionBuilder
-   */
-  public function taskRunInCurrentProcess($command) {
-    return $this->task(RunInCurrentProcess::class, $command);
-  }
+    /**
+     * @param string|\Robo\Contract\CommandInterface $command
+     *
+     * @return \Robo\Task\Base\Exec|\Robo\Collection\CollectionBuilder
+     */
+    public function taskRunInCurrentProcess($command) {
+        return $this->task(RunInCurrentProcess::class, $command);
+    }
 
 }


### PR DESCRIPTION
## OPENEUROPA

### Description

Running tasks from runner.yml creates a new process, with new config. It should not.
To keep BC, make it an option.

### Change log

- Added:
  - RunInCurrentProcess task
  - Add an optional "in-current-process: true" key that enables that behaviour.
  - Readme docs

### runner.yml example

```yml
commands:
  foo:
    tasks:
      - task: run
        in-current-process: true
        command: "drupal:drush-setup"
```

