### PR TITLE
DQA-4743: Allow robo version 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.4",
-        "consolidation/robo": "^3.0",
+        "consolidation/robo": "^3.0 | ^4.0",
         "gitonomy/gitlib": "^1.0",
         "jakeasmith/http_build_url": "^1.0.1",
         "nuvoleweb/robo-config": "^2.0"


### PR DESCRIPTION
## DQA-4743

### Description

We are working on Toolkit to make it compatible with the Drupal 10.
In this Pull request I am just allowing the installation of Robo version 4.
Here's the change log https://github.com/consolidation/robo/compare/3.0.10...4.0.0-alpha1
