### PR TITLE
OEL-2096: Changes in consolidation/annotated-command 4.5.7 break configuration initialisation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=7.4",
+        "consolidation/annotated-command": "^4.3 <4.5.7",
         "consolidation/robo": "^3.0",
         "gitonomy/gitlib": "^1.0",
         "jakeasmith/http_build_url": "^1.0.1",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["Robo", "automation", "task-runner", "yaml"],
     "license": "EUPL-1.2",
     "type": "library",
-    "minimum-stability": "dev",
+    "minimum-stability": "alpha",
     "prefer-stable": true,
     "require": {
         "php": ">=7.4",


### PR DESCRIPTION
Minimum stability is increased to alpha or a bunch of components will be updated, using dev-main of consolidation/log which is not ideal:
```
  - Upgrading psr/log (2.0.0 => 3.0.0): Extracting archive
  - Downgrading consolidation/annotated-command (4.5.7 => 4.5.6): Extracting archive
  - Upgrading consolidation/log (2.1.1 => dev-main e95baff): Extracting archive
```